### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/foyt/fni.png?label=ready&title=Ready)](https://waffle.io/foyt/fni)
 fni
 ===
 [![Build Status](https://travis-ci.org/foyt/fni.png?branch=devel)](https://travis-ci.org/foyt/fni)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/foyt/fni

This was requested by a real person (user anttileppa) on waffle.io, we're not trying to spam you.
